### PR TITLE
fix(smt): remove previously added async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,21 +31,6 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets",
-]
 
 [[package]]
 name = "bit-set"
@@ -175,12 +145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,21 +174,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
-name = "memchr"
-version = "2.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,25 +183,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "ppv-lite86"
@@ -359,12 +293,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
 name = "rustix"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,28 +348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
-dependencies = [
- "backtrace",
- "pin-project-lite",
- "tokio-macros",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,7 +373,6 @@ dependencies = [
  "anyhow",
  "hashbrown",
  "proptest",
- "tokio",
  "valence-coprocessor-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,3 @@ repository = "https://github.com/timewave-computer/valence-coprocessor"
 [workspace.dependencies]
 anyhow = { version = "=1.0.97", default-features = false }
 hashbrown = "=0.15.2"
-tokio = "=1.44.1"

--- a/crates/smt/Cargo.toml
+++ b/crates/smt/Cargo.toml
@@ -12,7 +12,6 @@ valence-coprocessor-core = { path = "../core", default-features = false }
 
 [dev-dependencies]
 proptest = "=1.6.0"
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 
 [features]
 std = ["anyhow/std", "valence-coprocessor-core/std"]

--- a/crates/smt/README.md
+++ b/crates/smt/README.md
@@ -80,7 +80,7 @@ sequenceDiagram
 ```rust
 // An ephemeral in-memory data backend
 #[cfg(feature = "memory")]
-async fn run() -> anyhow::Result<()> {
+fn run() -> anyhow::Result<()> {
     use valence_smt::MemorySmt;
 
     let context = "foo";
@@ -93,10 +93,10 @@ async fn run() -> anyhow::Result<()> {
     let root = MemorySmt::empty_tree_root();
 
     // appends the data into the tree, returning its new Merkle root
-    let root = tree.insert(root, context, data.to_vec()).await?;
+    let root = tree.insert(root, context, data.to_vec())?;
 
     // generates a Merkle opening proof
-    let proof = tree.get_opening(context, root, data).await?.unwrap();
+    let proof = tree.get_opening(context, root, data)?.unwrap();
 
     // asserts that the data opens to the provided root
     assert!(MemorySmt::verify(context, &root, &proof));

--- a/crates/smt/src/lib.rs
+++ b/crates/smt/src/lib.rs
@@ -4,8 +4,6 @@
 
 extern crate alloc;
 
-use core::future::Future;
-
 use alloc::vec::Vec;
 use valence_coprocessor_core::Hash;
 
@@ -30,58 +28,34 @@ pub use smt::*;
 pub trait TreeBackend {
     /// Appends a relationship from the parent node to its children within a binary tree
     /// structure, returning true if a prior relationship from the parent node was overwritten.
-    fn insert_children(
-        &mut self,
-        parent: &Hash,
-        children: &SmtChildren,
-    ) -> impl Future<Output = anyhow::Result<bool>>;
+    fn insert_children(&mut self, parent: &Hash, children: &SmtChildren) -> anyhow::Result<bool>;
 
     /// Fetches the children linked to the provided parent node.
-    fn get_children(
-        &self,
-        parent: &Hash,
-    ) -> impl Future<Output = anyhow::Result<Option<SmtChildren>>>;
+    fn get_children(&self, parent: &Hash) -> anyhow::Result<Option<SmtChildren>>;
 
     /// Removes a parent-children relationship from the storage, returning it.
-    fn remove_children(
-        &mut self,
-        parent: &Hash,
-    ) -> impl Future<Output = anyhow::Result<Option<SmtChildren>>>;
+    fn remove_children(&mut self, parent: &Hash) -> anyhow::Result<Option<SmtChildren>>;
 
     /// Assign a leaf key to a tree node, logically converting the node into a leaf node,
     /// returning `true` if a prior relationship of the provided node was overwritten.
-    fn insert_node_key(
-        &mut self,
-        node: &Hash,
-        leaf: &Hash,
-    ) -> impl Future<Output = anyhow::Result<bool>>;
+    fn insert_node_key(&mut self, node: &Hash, leaf: &Hash) -> anyhow::Result<bool>;
 
     /// Returns `true` if the provided node is associated with a leaf key.
-    fn has_node_key(&self, node: &Hash) -> impl Future<Output = anyhow::Result<bool>>;
+    fn has_node_key(&self, node: &Hash) -> anyhow::Result<bool>;
 
     /// Fetches the associated leaf key of the node.
-    fn get_node_key(&self, node: &Hash) -> impl Future<Output = anyhow::Result<Option<Hash>>>;
+    fn get_node_key(&self, node: &Hash) -> anyhow::Result<Option<Hash>>;
 
     /// Removes a node to leaf key association from the node, returning it.
-    fn remove_node_key(
-        &mut self,
-        node: &Hash,
-    ) -> impl Future<Output = anyhow::Result<Option<Hash>>>;
+    fn remove_node_key(&mut self, node: &Hash) -> anyhow::Result<Option<Hash>>;
 
     /// Assign a leaf data to a leaf key, returning `true` if a prior relationship of the
     /// provided key to a leaf data was overwritten.
-    fn insert_key_data(
-        &mut self,
-        key: &Hash,
-        data: Vec<u8>,
-    ) -> impl Future<Output = anyhow::Result<bool>>;
+    fn insert_key_data(&mut self, key: &Hash, data: Vec<u8>) -> anyhow::Result<bool>;
 
     /// Fetches the associated leaf data to the provided leaf key.
-    fn get_key_data(&self, key: &Hash) -> impl Future<Output = anyhow::Result<Option<Vec<u8>>>>;
+    fn get_key_data(&self, key: &Hash) -> anyhow::Result<Option<Vec<u8>>>;
 
     /// Removes a leaf key data association, returning it.
-    fn remove_key_data(
-        &mut self,
-        key: &Hash,
-    ) -> impl Future<Output = anyhow::Result<Option<Vec<u8>>>>;
+    fn remove_key_data(&mut self, key: &Hash) -> anyhow::Result<Option<Vec<u8>>>;
 }

--- a/crates/smt/src/memory.rs
+++ b/crates/smt/src/memory.rs
@@ -1,5 +1,3 @@
-use core::future::{self, Future};
-
 use alloc::vec::Vec;
 use hashbrown::HashMap;
 use valence_coprocessor_core::{Blake3Context, Hash};
@@ -18,99 +16,74 @@ pub struct MemoryBackend {
 }
 
 impl TreeBackend for MemoryBackend {
-    fn insert_children(
-        &mut self,
-        parent: &Hash,
-        children: &SmtChildren,
-    ) -> impl Future<Output = anyhow::Result<bool>> {
-        future::ready(Ok(self.children.insert(*parent, *children).is_some()))
+    fn insert_children(&mut self, parent: &Hash, children: &SmtChildren) -> anyhow::Result<bool> {
+        Ok(self.children.insert(*parent, *children).is_some())
     }
 
-    fn get_children(
-        &self,
-        parent: &Hash,
-    ) -> impl Future<Output = anyhow::Result<Option<SmtChildren>>> {
-        future::ready(Ok(self.children.get(parent).copied()))
+    fn get_children(&self, parent: &Hash) -> anyhow::Result<Option<SmtChildren>> {
+        Ok(self.children.get(parent).copied())
     }
 
-    fn remove_children(
-        &mut self,
-        parent: &Hash,
-    ) -> impl Future<Output = anyhow::Result<Option<SmtChildren>>> {
-        future::ready(Ok(self.children.remove(parent)))
+    fn remove_children(&mut self, parent: &Hash) -> anyhow::Result<Option<SmtChildren>> {
+        Ok(self.children.remove(parent))
     }
 
-    fn insert_node_key(
-        &mut self,
-        node: &Hash,
-        leaf: &Hash,
-    ) -> impl Future<Output = anyhow::Result<bool>> {
-        future::ready(Ok(self.keys.insert(*node, *leaf).is_some()))
+    fn insert_node_key(&mut self, node: &Hash, leaf: &Hash) -> anyhow::Result<bool> {
+        Ok(self.keys.insert(*node, *leaf).is_some())
     }
 
-    fn has_node_key(&self, node: &Hash) -> impl Future<Output = anyhow::Result<bool>> {
-        future::ready(Ok(self.keys.get(node).is_some()))
+    fn has_node_key(&self, node: &Hash) -> anyhow::Result<bool> {
+        Ok(self.keys.get(node).is_some())
     }
 
-    fn get_node_key(&self, node: &Hash) -> impl Future<Output = anyhow::Result<Option<Hash>>> {
-        future::ready(Ok(self.keys.get(node).copied()))
+    fn get_node_key(&self, node: &Hash) -> anyhow::Result<Option<Hash>> {
+        Ok(self.keys.get(node).copied())
     }
 
-    fn remove_node_key(
-        &mut self,
-        node: &Hash,
-    ) -> impl Future<Output = anyhow::Result<Option<Hash>>> {
-        future::ready(Ok(self.keys.remove(node)))
+    fn remove_node_key(&mut self, node: &Hash) -> anyhow::Result<Option<Hash>> {
+        Ok(self.keys.remove(node))
     }
 
-    fn insert_key_data(
-        &mut self,
-        key: &Hash,
-        data: Vec<u8>,
-    ) -> impl Future<Output = anyhow::Result<bool>> {
-        future::ready(Ok(self.data.insert(*key, data).is_some()))
+    fn insert_key_data(&mut self, key: &Hash, data: Vec<u8>) -> anyhow::Result<bool> {
+        Ok(self.data.insert(*key, data).is_some())
     }
 
-    fn get_key_data(&self, key: &Hash) -> impl Future<Output = anyhow::Result<Option<Vec<u8>>>> {
-        future::ready(Ok(self.data.get(key).cloned()))
+    fn get_key_data(&self, key: &Hash) -> anyhow::Result<Option<Vec<u8>>> {
+        Ok(self.data.get(key).cloned())
     }
 
-    fn remove_key_data(
-        &mut self,
-        key: &Hash,
-    ) -> impl Future<Output = anyhow::Result<Option<Vec<u8>>>> {
-        future::ready(Ok(self.data.remove(key)))
+    fn remove_key_data(&mut self, key: &Hash) -> anyhow::Result<Option<Vec<u8>>> {
+        Ok(self.data.remove(key))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use proptest::prelude::*;
-    use tokio::runtime::Runtime;
     use valence_coprocessor_core::{Blake3Hasher, Hasher as _};
 
     use crate::SmtOpening;
 
     use super::*;
 
-    #[tokio::test]
-    async fn single_node_opening() -> anyhow::Result<()> {
+    #[test]
+    fn single_node_opening() -> anyhow::Result<()> {
         let context = "poem";
         let data = b"Two roads diverged in a wood, and I took the one less traveled by";
 
         let mut tree = MemorySmt::default();
 
         let root = MemorySmt::empty_tree_root();
-        let root = tree.insert(root, context, data.to_vec()).await?;
-        let proof = tree.get_opening(context, root, data).await?.unwrap();
+        let root = tree.insert(root, context, data.to_vec())?;
+        let proof = tree.get_opening(context, root, data)?.unwrap();
 
         assert!(MemorySmt::verify(context, &root, &proof));
 
         Ok(())
     }
 
-    #[tokio::test]
-    async fn double_node_opening() -> anyhow::Result<()> {
+    #[test]
+    fn double_node_opening() -> anyhow::Result<()> {
         let context = "poem";
 
         let data = [
@@ -127,12 +100,12 @@ mod tests {
         let mut tree = MemorySmt::default();
         let root = MemorySmt::empty_tree_root();
 
-        let root = tree.insert(root, context, data[0].to_vec()).await?;
-        let root = tree.insert(root, context, data[1].to_vec()).await?;
+        let root = tree.insert(root, context, data[0].to_vec())?;
+        let root = tree.insert(root, context, data[1].to_vec())?;
 
         let proofs = [
-            tree.get_opening(context, root, &data[0]).await?.unwrap(),
-            tree.get_opening(context, root, &data[1]).await?.unwrap(),
+            tree.get_opening(context, root, &data[0])?.unwrap(),
+            tree.get_opening(context, root, &data[1])?.unwrap(),
         ];
 
         assert!(MemorySmt::verify(context, &root, &proofs[0]));
@@ -141,8 +114,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn double_one_bit_collision() -> anyhow::Result<()> {
+    #[test]
+    fn double_one_bit_collision() -> anyhow::Result<()> {
         let context = "poem";
         let data = b"And miles to go before I sleep.";
         let collision = [0x00, 0x00, 0x00];
@@ -157,12 +130,12 @@ mod tests {
         let mut tree = MemorySmt::default();
         let root = MemorySmt::empty_tree_root();
 
-        let root = tree.insert(root, context, data.to_vec()).await?;
-        let root = tree.insert(root, context, collision.to_vec()).await?;
+        let root = tree.insert(root, context, data.to_vec())?;
+        let root = tree.insert(root, context, collision.to_vec())?;
 
         let proofs = [
-            tree.get_opening(context, root, data).await?.unwrap(),
-            tree.get_opening(context, root, &collision).await?.unwrap(),
+            tree.get_opening(context, root, data)?.unwrap(),
+            tree.get_opening(context, root, &collision)?.unwrap(),
         ];
 
         assert_eq!(proofs[0].opening.len(), 2);
@@ -174,8 +147,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn double_two_bit_collision() -> anyhow::Result<()> {
+    #[test]
+    fn double_two_bit_collision() -> anyhow::Result<()> {
         let context = "poem";
         let data = b"And miles to go before I sleep.";
         let collision = [0x00, 0x00, 0x02];
@@ -191,12 +164,12 @@ mod tests {
         let mut tree = MemorySmt::default();
         let root = MemorySmt::empty_tree_root();
 
-        let root = tree.insert(root, context, data.to_vec()).await?;
-        let root = tree.insert(root, context, collision.to_vec()).await?;
+        let root = tree.insert(root, context, data.to_vec())?;
+        let root = tree.insert(root, context, collision.to_vec())?;
 
         let proofs = [
-            tree.get_opening(context, root, data).await?.unwrap(),
-            tree.get_opening(context, root, &collision).await?.unwrap(),
+            tree.get_opening(context, root, data)?.unwrap(),
+            tree.get_opening(context, root, &collision)?.unwrap(),
         ];
 
         assert_eq!(proofs[0].opening.len(), 3);
@@ -208,8 +181,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn double_long_collision() -> anyhow::Result<()> {
+    #[test]
+    fn double_long_collision() -> anyhow::Result<()> {
         let context = "poem";
         let data = b"And miles to go before I sleep.";
         let collision = [0x25, 0x80, 0x30];
@@ -225,12 +198,12 @@ mod tests {
         let mut tree = MemorySmt::default();
         let root = MemorySmt::empty_tree_root();
 
-        let root = tree.insert(root, context, data.to_vec()).await?;
-        let root = tree.insert(root, context, collision.to_vec()).await?;
+        let root = tree.insert(root, context, data.to_vec())?;
+        let root = tree.insert(root, context, collision.to_vec())?;
 
         let proofs = [
-            tree.get_opening(context, root, data).await?.unwrap(),
-            tree.get_opening(context, root, &collision).await?.unwrap(),
+            tree.get_opening(context, root, data)?.unwrap(),
+            tree.get_opening(context, root, &collision)?.unwrap(),
         ];
 
         assert_eq!(proofs[0].opening.len(), 12);
@@ -242,8 +215,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn complex_tree() -> anyhow::Result<()> {
+    #[test]
+    fn complex_tree() -> anyhow::Result<()> {
         let context = "poem";
         let mask = 0b11100000u8;
 
@@ -278,9 +251,9 @@ mod tests {
 
         // R = 0
 
-        let root = tree.insert(root, context, data[0].to_vec()).await?;
+        let root = tree.insert(root, context, data[0].to_vec())?;
 
-        proofs[0] = tree.get_opening(context, root, &data[0]).await?.unwrap();
+        proofs[0] = tree.get_opening(context, root, &data[0])?.unwrap();
 
         assert_eq!(proofs[0].opening.len(), 0);
 
@@ -294,10 +267,10 @@ mod tests {
         //    / \
         //   0   1
 
-        let root = tree.insert(root, context, data[1].to_vec()).await?;
+        let root = tree.insert(root, context, data[1].to_vec())?;
 
-        proofs[0] = tree.get_opening(context, root, &data[0]).await?.unwrap();
-        proofs[1] = tree.get_opening(context, root, &data[1]).await?.unwrap();
+        proofs[0] = tree.get_opening(context, root, &data[0])?.unwrap();
+        proofs[1] = tree.get_opening(context, root, &data[1])?.unwrap();
 
         assert_eq!(proofs[0].opening.len(), 2);
         assert_eq!(proofs[1].opening.len(), 2);
@@ -316,11 +289,11 @@ mod tests {
         //  / \
         // 0   2
 
-        let root = tree.insert(root, context, data[2].to_vec()).await?;
+        let root = tree.insert(root, context, data[2].to_vec())?;
 
-        proofs[0] = tree.get_opening(context, root, &data[0]).await?.unwrap();
-        proofs[1] = tree.get_opening(context, root, &data[1]).await?.unwrap();
-        proofs[2] = tree.get_opening(context, root, &data[2]).await?.unwrap();
+        proofs[0] = tree.get_opening(context, root, &data[0])?.unwrap();
+        proofs[1] = tree.get_opening(context, root, &data[1])?.unwrap();
+        proofs[2] = tree.get_opening(context, root, &data[2])?.unwrap();
 
         assert_eq!(proofs[0].opening.len(), 3);
         assert_eq!(proofs[1].opening.len(), 2);
@@ -342,12 +315,12 @@ mod tests {
         //  / \
         // 0   2
 
-        let root = tree.insert(root, context, data[3].to_vec()).await?;
+        let root = tree.insert(root, context, data[3].to_vec())?;
 
-        proofs[0] = tree.get_opening(context, root, &data[0]).await?.unwrap();
-        proofs[1] = tree.get_opening(context, root, &data[1]).await?.unwrap();
-        proofs[2] = tree.get_opening(context, root, &data[2]).await?.unwrap();
-        proofs[3] = tree.get_opening(context, root, &data[3]).await?.unwrap();
+        proofs[0] = tree.get_opening(context, root, &data[0])?.unwrap();
+        proofs[1] = tree.get_opening(context, root, &data[1])?.unwrap();
+        proofs[2] = tree.get_opening(context, root, &data[2])?.unwrap();
+        proofs[3] = tree.get_opening(context, root, &data[3])?.unwrap();
 
         assert!(MemorySmt::verify(context, &root, &proofs[0]));
         assert!(MemorySmt::verify(context, &root, &proofs[1]));
@@ -362,8 +335,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn deep_opening() -> anyhow::Result<()> {
+    #[test]
+    fn deep_opening() -> anyhow::Result<()> {
         let n = [1778514084u32, 252724253, 45104643];
 
         let ctx = "property";
@@ -372,12 +345,9 @@ mod tests {
 
         // R = 0
 
-        let root = tree.insert(root, ctx, n[0].to_le_bytes().to_vec()).await?;
+        let root = tree.insert(root, ctx, n[0].to_le_bytes().to_vec())?;
 
-        let p0 = tree
-            .get_opening(ctx, root, &n[0].to_le_bytes())
-            .await?
-            .unwrap();
+        let p0 = tree.get_opening(ctx, root, &n[0].to_le_bytes())?.unwrap();
 
         assert_eq!(&p0.data, &n[0].to_le_bytes());
 
@@ -387,16 +357,10 @@ mod tests {
         //  / \
         // 1   0
 
-        let root = tree.insert(root, ctx, n[1].to_le_bytes().to_vec()).await?;
+        let root = tree.insert(root, ctx, n[1].to_le_bytes().to_vec())?;
 
-        let p0 = tree
-            .get_opening(ctx, root, &n[0].to_le_bytes())
-            .await?
-            .unwrap();
-        let p1 = tree
-            .get_opening(ctx, root, &n[1].to_le_bytes())
-            .await?
-            .unwrap();
+        let p0 = tree.get_opening(ctx, root, &n[0].to_le_bytes())?.unwrap();
+        let p1 = tree.get_opening(ctx, root, &n[1].to_le_bytes())?.unwrap();
 
         assert_eq!(&p0.data, &n[0].to_le_bytes());
         assert_eq!(&p1.data, &n[1].to_le_bytes());
@@ -414,20 +378,11 @@ mod tests {
         //  / \
         // 0   2
 
-        let root = tree.insert(root, ctx, n[2].to_le_bytes().to_vec()).await?;
+        let root = tree.insert(root, ctx, n[2].to_le_bytes().to_vec())?;
 
-        let p0 = tree
-            .get_opening(ctx, root, &n[0].to_le_bytes())
-            .await?
-            .unwrap();
-        let p1 = tree
-            .get_opening(ctx, root, &n[1].to_le_bytes())
-            .await?
-            .unwrap();
-        let p2 = tree
-            .get_opening(ctx, root, &n[2].to_le_bytes())
-            .await?
-            .unwrap();
+        let p0 = tree.get_opening(ctx, root, &n[0].to_le_bytes())?.unwrap();
+        let p1 = tree.get_opening(ctx, root, &n[1].to_le_bytes())?.unwrap();
+        let p2 = tree.get_opening(ctx, root, &n[2].to_le_bytes())?.unwrap();
 
         assert_eq!(&p0.data, &n[0].to_le_bytes());
         assert_eq!(&p1.data, &n[1].to_le_bytes());
@@ -448,28 +403,24 @@ mod tests {
             let mut root = MemorySmt::empty_tree_root();
             let mut values = Vec::with_capacity(numbers.len());
 
-            let rt = Runtime::new().unwrap();
+            for n in numbers {
+                let data = n.to_le_bytes();
 
-            rt.block_on(async {
-                for n in numbers {
-                    let data = n.to_le_bytes();
+                values.push(data);
 
-                    values.push(data);
+                root = tree.insert(root, context, data.to_vec()).unwrap();
 
-                    root = tree.insert(root, context, data.to_vec()).await.unwrap();
+                let proof = tree.get_opening(context, root, &data).unwrap().unwrap();
 
-                    let proof = tree.get_opening(context, root, &data).await.unwrap().unwrap();
+                assert!(MemorySmt::verify(context, &root, &proof));
+            }
 
-                    assert!(MemorySmt::verify(context, &root, &proof));
-                }
+            for v in values {
+                let proof = tree.get_opening(context, root, &v).unwrap().unwrap();
 
-                for v in values {
-                    let proof = tree.get_opening(context, root, &v).await.unwrap().unwrap();
-
-                    assert!(MemorySmt::verify(context, &root, &proof));
-                    assert_eq!(&v, proof.data.as_slice());
-                }
-            });
+                assert!(MemorySmt::verify(context, &root, &proof));
+                assert_eq!(&v, proof.data.as_slice());
+            }
         }
     }
 }


### PR DESCRIPTION
The target data backend - rocksdb - doesn't use async on its implementation. Therefore, async is not required for now; it could be added in the future, if needed. For the target implementation, it will be only an overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the dependency on the asynchronous runtime library.

- **Refactor**
  - Streamlined functionality by converting several operations from asynchronous to synchronous execution, resulting in a simplified and more predictable interface for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->