### PR TITLE
fix: add domain block empty smt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-valence"
-version = "0.1.13"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3526,9 +3526,9 @@ dependencies = [
 
 [[package]]
 name = "msgpacker"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db10f6b26b3a8b743c088b3a80e6ebc78ac052e0ee11ca6e261d678ad09e3b41"
+checksum = "134a72ec3a6d034e9c767344ce8aebde228eef4e1343fff3ea209993f12920b3"
 dependencies = [
  "msgpacker-derive",
 ]
@@ -6962,7 +6962,7 @@ checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 
 [[package]]
 name = "valence-coprocessor"
-version = "0.1.13"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6981,7 +6981,7 @@ dependencies = [
 
 [[package]]
 name = "valence-coprocessor-ethereum"
-version = "0.1.13"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "common",
@@ -6995,7 +6995,7 @@ dependencies = [
 
 [[package]]
 name = "valence-coprocessor-prover"
-version = "0.1.13"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7017,7 +7017,7 @@ dependencies = [
 
 [[package]]
 name = "valence-coprocessor-redis"
-version = "0.1.13"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "r2d2",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "valence-coprocessor-service"
-version = "0.1.13"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -7051,7 +7051,7 @@ dependencies = [
 
 [[package]]
 name = "valence-coprocessor-sp1"
-version = "0.1.13"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -7072,7 +7072,7 @@ dependencies = [
 
 [[package]]
 name = "valence-coprocessor-wasm"
-version = "0.1.13"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dlmalloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default-members = ["crates/core"]
 authors = ["Timewave Labs"]
 edition = "2021"
 license = "Apache-2.0"
-version = "0.1.13"
+version = "0.2.0"
 repository = "https://github.com/timewave-computer/valence-coprocessor"
 
 [workspace.dependencies]
@@ -29,7 +29,7 @@ clap = { version = "4.5.37", features = ["derive"] }
 hashbrown = "0.15.2"
 hex = "0.4.3"
 lru = "0.14.0"
-msgpacker = { version = "0.4.7", default-features = false, features = [
+msgpacker = { version = "0.4.8", default-features = false, features = [
   "alloc",
   "derive",
 ] }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To install:
 ```sh
 cargo install \
   --git https://github.com/timewave-computer/valence-coprocessor.git \
-  --tag v0.1.13 \
+  --tag v0.2.0 \
   --locked cargo-valence
 ```
 

--- a/crates/core/src/registry/types.rs
+++ b/crates/core/src/registry/types.rs
@@ -1,5 +1,5 @@
 use alloc::{string::String, vec, vec::Vec};
-use msgpacker::{MsgPacker, Packable as _, Unpackable as _};
+use msgpacker::{MsgPacker, Packable as _, Unpackable};
 use serde::{Deserialize, Serialize};
 
 use crate::{Base64, Blake3Hasher, DataBackend, Hash, Hasher};
@@ -112,7 +112,7 @@ pub struct StateProof {
 }
 
 /// A circuit witness data obtained via Valence API.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, MsgPacker)]
 pub enum Witness {
     /// A domain opening of a state argument to its root.
     StateProof(StateProof),
@@ -225,6 +225,23 @@ impl<D: DataBackend> From<D> for Registry<D> {
     fn from(data: D) -> Self {
         Self { data }
     }
+}
+
+/// A confirmation of an added block.
+#[derive(
+    Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, MsgPacker,
+)]
+pub struct BlockAdded {
+    /// Domain to which the block was added.
+    pub domain: String,
+    /// Historical SMT root prior to the mutation.
+    pub prev_smt: Hash,
+    /// Historical SMT root after the mutation.
+    pub smt: Hash,
+    /// Controller execution log.
+    pub log: Vec<String>,
+    /// Block data.
+    pub block: ValidatedDomainBlock,
 }
 
 #[test]

--- a/crates/core/src/smt/README.md
+++ b/crates/core/src/smt/README.md
@@ -81,7 +81,7 @@ sequenceDiagram
 // An ephemeral in-memory data backend
 #[cfg(feature = "std")]
 fn run() -> anyhow::Result<()> {
-    use valence_coprocessor::MemorySmt;
+    use valence_coprocessor::{Blake3Hasher, Hasher as _, MemorySmt};
 
     let key = b"bar";
     let data = b"baz".to_vec();
@@ -93,7 +93,7 @@ fn run() -> anyhow::Result<()> {
     let root = MemorySmt::empty_tree_root();
 
     // computes the SMT key from the data
-    let key = MemorySmt::key(key);
+    let key = Blake3Hasher::key("context", key);
 
     // appends the data into the tree, returning its new Merkle root
     let root = tree.insert(root, &key, &data)?;

--- a/crates/core/src/smt/mod.rs
+++ b/crates/core/src/smt/mod.rs
@@ -181,7 +181,6 @@ where
 
         let mut node = root;
         let mut opening = Vec::with_capacity(HASH_LEN * 8);
-        let mut is_leaf = false;
 
         // traverse until leaf
         while let Some(SmtChildren { left, right }) = self.get_children(&node)? {
@@ -215,8 +214,6 @@ where
                 node = children.parent::<H>();
 
                 self.insert_children(&node, &children)?;
-
-                is_leaf = true;
 
                 break;
             }
@@ -254,13 +251,9 @@ where
 
                 self.insert_children(&node, &children)?;
 
-                is_leaf = true;
-
                 break;
             }
         }
-
-        anyhow::ensure!(is_leaf, "inconsistent tree state; the root {root:x?} traversed up to {node:x?}, but that node isn't a leaf");
 
         while let Some(sibling) = opening.pop() {
             depth -= 1;
@@ -281,11 +274,6 @@ where
         }
 
         Ok(node)
-    }
-
-    /// A helper to compute the key from arbitrary bytes.
-    pub fn key<K: AsRef<[u8]>>(data: K) -> Hash {
-        H::hash(data.as_ref())
     }
 
     /// Verifies a Merkle opening generated via [`Smt::get_opening`].

--- a/crates/core/src/smt/tests.rs
+++ b/crates/core/src/smt/tests.rs
@@ -10,7 +10,7 @@ fn single_node_opening() -> anyhow::Result<()> {
     let data = b"Two roads diverged in a wood, and I took the one less traveled by";
 
     let tree = MemorySmt::default();
-    let key = MemorySmt::key(context);
+    let key = Blake3Hasher::key(context, &[]);
 
     let root = MemorySmt::empty_tree_root();
     let root = tree.insert(root, &key, data)?;

--- a/crates/core/src/smt/types.rs
+++ b/crates/core/src/smt/types.rs
@@ -149,6 +149,11 @@ where
             .map(|o| o.try_into().unwrap_or_default()))
     }
 
+    /// Returns the payload of the provided domain root on the historical SMT.
+    pub fn get_key_data(&self, key: &Hash) -> anyhow::Result<Option<Vec<u8>>> {
+        self.d.get(Self::PREFIX_DATA, key)
+    }
+
     pub(super) fn remove_key_data(&self, key: &Hash) -> anyhow::Result<Option<Vec<u8>>> {
         self.d.remove(Self::PREFIX_DATA, key)
     }

--- a/crates/core/src/zkvm.rs
+++ b/crates/core/src/zkvm.rs
@@ -21,7 +21,7 @@ pub struct DomainOpening {
 }
 
 /// A circuit witness data obtained via Valence API.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, MsgPacker)]
 pub struct WitnessCoprocessor {
     /// Co-processor historical commitments root.
     pub root: Hash,

--- a/crates/runtime/wasm/contrib/Cargo.lock
+++ b/crates/runtime/wasm/contrib/Cargo.lock
@@ -182,9 +182,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "msgpacker"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db10f6b26b3a8b743c088b3a80e6ebc78ac052e0ee11ca6e261d678ad09e3b41"
+checksum = "134a72ec3a6d034e9c767344ce8aebde228eef4e1343fff3ea209993f12920b3"
 dependencies = [
  "msgpacker-derive",
 ]
@@ -317,7 +317,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "valence-coprocessor"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "valence-coprocessor-wasm"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dlmalloc",

--- a/crates/runtime/wasm/contrib/domain/src/lib.rs
+++ b/crates/runtime/wasm/contrib/domain/src/lib.rs
@@ -1,18 +1,45 @@
 #![no_std]
 
-use valence_coprocessor_wasm::abi;
+use valence_coprocessor_wasm::{abi, core::ValidatedDomainBlock};
 
 extern crate alloc;
 
 #[no_mangle]
 pub extern "C" fn entrypoint() {
     let args = abi::args().unwrap();
-
+    let cmd = args["cmd"].as_str().unwrap();
     let domain = args["domain"].as_str().unwrap();
-    let block = abi::get_latest_block(domain).unwrap();
-    let block = serde_json::to_value(&block).unwrap();
 
-    abi::ret(&block).unwrap();
+    let ret = match cmd {
+        "latest" => {
+            let block = abi::get_latest_block(domain).unwrap();
+            let block = serde_json::to_value(&block).unwrap();
+
+            block
+        }
+
+        "opening" => {
+            let historical = abi::get_historical().unwrap();
+            let ValidatedDomainBlock { root, key, .. } =
+                abi::get_latest_block(domain).unwrap().unwrap();
+            let payload = abi::get_historical_payload(domain, &root).unwrap().unwrap();
+            let opening = abi::get_historical_opening(&historical, domain, &root)
+                .unwrap()
+                .unwrap();
+
+            serde_json::json!({
+                "historical": historical,
+                "root": root,
+                "key": key,
+                "payload": payload,
+                "opening": opening,
+            })
+        }
+
+        _ => panic!("unknown command"),
+    };
+
+    abi::ret(&ret).unwrap();
 }
 
 #[no_mangle]

--- a/crates/runtime/wasm/src/host/mod.rs
+++ b/crates/runtime/wasm/src/host/mod.rs
@@ -81,6 +81,17 @@ where
         linker.func_wrap(HOST_CONTROLLER, "get_raw_storage", valence::get_raw_storage)?;
         linker.func_wrap(HOST_CONTROLLER, "set_raw_storage", valence::set_raw_storage)?;
         linker.func_wrap(HOST_CONTROLLER, "get_controller", valence::get_controller)?;
+        linker.func_wrap(HOST_CONTROLLER, "get_historical", valence::get_historical)?;
+        linker.func_wrap(
+            HOST_CONTROLLER,
+            "get_historical_opening",
+            valence::get_historical_opening,
+        )?;
+        linker.func_wrap(
+            HOST_CONTROLLER,
+            "get_historical_payload",
+            valence::get_historical_payload,
+        )?;
         linker.func_wrap(
             HOST_CONTROLLER,
             "get_latest_block",

--- a/crates/runtime/wasm/src/lib.rs
+++ b/crates/runtime/wasm/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 
 pub mod abi;
+pub use valence_coprocessor as core;
 
 #[cfg(feature = "std")]
 pub mod host;

--- a/tests/service/Cargo.lock
+++ b/tests/service/Cargo.lock
@@ -2946,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "msgpacker"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db10f6b26b3a8b743c088b3a80e6ebc78ac052e0ee11ca6e261d678ad09e3b41"
+checksum = "134a72ec3a6d034e9c767344ce8aebde228eef4e1343fff3ea209993f12920b3"
 dependencies = [
  "msgpacker-derive",
 ]
@@ -5919,7 +5919,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valence-coprocessor"
-version = "0.1.11"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "base64",
@@ -5978,7 +5978,7 @@ dependencies = [
 
 [[package]]
 name = "valence-coprocessor-sp1"
-version = "0.1.11"
+version = "0.1.13"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -5992,7 +5992,7 @@ dependencies = [
 
 [[package]]
 name = "valence-coprocessor-wasm"
-version = "0.1.11"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "dlmalloc",

--- a/tests/service/circuit/Cargo.lock
+++ b/tests/service/circuit/Cargo.lock
@@ -2876,9 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "msgpacker"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db10f6b26b3a8b743c088b3a80e6ebc78ac052e0ee11ca6e261d678ad09e3b41"
+checksum = "134a72ec3a6d034e9c767344ce8aebde228eef4e1343fff3ea209993f12920b3"
 dependencies = [
  "msgpacker-derive",
 ]
@@ -5783,7 +5783,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valence-coprocessor"
-version = "0.1.11"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "base64",
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "valence-coprocessor-integrated-tests-domain"
-version = "0.1.11"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "valence-coprocessor-sp1"
-version = "0.1.11"
+version = "0.1.13"
 dependencies = [
  "ark-bn254",
  "ark-ec",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new API endpoints and WASM ABI functions for accessing historical Sparse Merkle Tree (SMT) data, including fetching historical roots, openings, and payloads.
  - Enhanced domain controller to support commands for retrieving both the latest block and detailed SMT opening data.
  - API responses for adding domain blocks now include detailed SMT state and block information.

- **Improvements**
  - Added new response structures to API endpoints for richer and more informative results.
  - Improved installation and usage documentation with updated version references and clearer SMT example code.
  - Added message packing support to several data structures for improved serialization.

- **Bug Fixes**
  - Adjusted block addition logic to prevent older blocks from overwriting newer ones and improved SMT state tracking.

- **Tests**
  - Expanded and enhanced tests to verify SMT state transitions, opening proofs, and correct block addition behavior.

- **Chores**
  - Updated package and dependency versions for improved compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->