### PR TITLE
adds browser-like wasi http api to enable portable clients

### DIFF
--- a/crates/runtime/wasm/contrib/Cargo.lock
+++ b/crates/runtime/wasm/contrib/Cargo.lock
@@ -317,7 +317,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "valence-coprocessor"
-version = "0.3.1"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "valence-coprocessor-wasm"
-version = "0.3.1"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -387,6 +387,15 @@ dependencies = [
 name = "valence-coprocessor-wasm-log"
 version = "0.1.0"
 dependencies = [
+ "serde_json",
+ "valence-coprocessor-wasm",
+]
+
+[[package]]
+name = "valence-coprocessor-wasm-portable_http_client"
+version = "0.1.0"
+dependencies = [
+ "serde",
  "serde_json",
  "valence-coprocessor-wasm",
 ]

--- a/crates/runtime/wasm/contrib/Cargo.toml
+++ b/crates/runtime/wasm/contrib/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "hello",
   "http",
   "log",
+  "portable_http_client",
   "raw_storage",
   "storage",
 ]

--- a/crates/runtime/wasm/contrib/portable_http_client/Cargo.toml
+++ b/crates/runtime/wasm/contrib/portable_http_client/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "valence-coprocessor-wasm-portable_http_client"
+edition = "2021"
+license = "Business Source License"
+version = "0.1.0"
+
+[dependencies]
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde_json.workspace = true
+valence-coprocessor-wasm = { path = "../..", default-features = false, features = ["abi-handlers"] }
+
+[lib]
+crate-type = ["cdylib"] 

--- a/crates/runtime/wasm/contrib/portable_http_client/README.md
+++ b/crates/runtime/wasm/contrib/portable_http_client/README.md
@@ -1,0 +1,68 @@
+# HTTP Client - Portable WASM Module
+
+A portable HTTP client WASM module that works in both browser and Valence coprocessor environments. This demonstrates how to create WASM binaries that can make HTTP calls across different runtime environments.
+
+This example demonstrates the interaction with the coprocessor portability logic located at `crates/runtime/wasm/src/portable.rs`.
+
+## Features
+
+- **Portable**: Works in both browser and Valence coprocessor environments
+- **Generic HTTP Interface**: Can interact with any HTTP-based API
+- **JSON-RPC Support**: Built-in support for JSON-RPC protocols (commonly used by blockchain nodes)
+- **REST API Support**: Flexible REST API calling capabilities
+
+## Usage
+
+### Generic HTTP Commands
+
+#### GET Request
+```json
+{
+  "command": "http_get",
+  "url": "https://api.example.com/data",
+  "headers": {
+    "Authorization": "Bearer token",
+    "Accept": "application/json"
+  }
+}
+```
+
+#### POST Request
+```json
+{
+  "command": "http_post",
+  "url": "https://api.example.com/submit",
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "json": {
+    "data": "value"
+  }
+}
+```
+
+#### REST API Call
+```json
+{
+  "command": "rest_api",
+  "url": "https://api.example.com/endpoint",
+  "method": "GET"
+}
+```
+
+## Building
+
+```bash
+cargo build --target wasm32-unknown-unknown --release
+```
+
+The compiled WASM binary will be portable across both browser and Valence environments.
+
+## Architecture
+
+The module provides a common HTTP abstraction layer that:
+
+1. **In Valence Environment**: Uses the built-in `abi::http` host function
+2. **In Browser Environment**: Can be configured to use `fetch` API (via wasm-bindgen)
+
+The portable interface provides a common API surface that works across both environments, allowing the same WASM binary to run in different contexts.

--- a/crates/runtime/wasm/contrib/portable_http_client/src/lib.rs
+++ b/crates/runtime/wasm/contrib/portable_http_client/src/lib.rs
@@ -1,0 +1,430 @@
+//! HTTP Client - A portable WASM module for making HTTP requests
+//!
+//! This module demonstrates how to create WASM binaries that can make HTTP calls
+//! to any HTTP-based API in both browser and Valence coprocessor environments.
+//! While the examples focus on blockchain/Ethereum JSON-RPC, the HTTP interface
+//! is completely generic and can be used with any REST API, GraphQL endpoint,
+//! or other HTTP-based service.
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{string::String, format};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use valence_coprocessor_wasm::{abi, portable::*};
+
+/// Generic JSON-RPC request
+#[derive(Debug, Serialize)]
+struct JsonRpcRequest {
+    jsonrpc: String,
+    method: String,
+    params: Value,
+    id: u64,
+}
+
+/// Generic JSON-RPC response
+#[derive(Debug, Deserialize)]
+struct JsonRpcResponse {
+    jsonrpc: String,
+    result: Option<Value>,
+    error: Option<JsonRpcError>,
+    id: u64,
+}
+
+/// JSON-RPC error
+#[derive(Debug, Deserialize)]
+struct JsonRpcError {
+    code: i64,
+    message: String,
+    data: Option<Value>,
+}
+
+/// Block information structure (Ethereum example)
+#[derive(Debug, Deserialize)]
+struct BlockInfo {
+    number: String,
+    hash: String,
+    #[serde(rename = "parentHash")]
+    parent_hash: String,
+    timestamp: String,
+    #[serde(rename = "gasLimit")]
+    gas_limit: String,
+    #[serde(rename = "gasUsed")]
+    gas_used: String,
+}
+
+/// Account balance information (Ethereum example)
+#[derive(Debug, Deserialize)]
+struct AccountInfo {
+    balance: String,
+    nonce: u64,
+}
+
+/// Main entrypoint for the HTTP client
+#[no_mangle]
+pub extern "C" fn entrypoint() {
+    let args = abi::args().unwrap();
+    
+    let command = args["command"].as_str().unwrap_or("help");
+    
+    let result = match command {
+        // Ethereum/Blockchain specific commands (examples)
+        "get_block" => get_block_info(&args),
+        "get_balance" => get_account_balance(&args),
+        "get_transaction" => get_transaction(&args),
+        "eth_call" => make_eth_call(&args),
+        "test_connection" => test_node_connection(&args),
+        
+        // Generic HTTP commands
+        "http_get" => make_http_get(&args),
+        "http_post" => make_http_post(&args),
+        "rest_api" => call_rest_api(&args),
+        
+        "help" => show_help(),
+        _ => Err(format!("Unknown command: {}", command)),
+    };
+
+    let response = match result {
+        Ok(data) => json!({
+            "success": true,
+            "data": data
+        }),
+        Err(error) => json!({
+            "success": false,
+            "error": error
+        })
+    };
+
+    abi::ret(&response).unwrap();
+}
+
+/// Make a generic HTTP GET request
+fn make_http_get(args: &Value) -> Result<Value, String> {
+    let url = args["url"].as_str()
+        .ok_or("Missing 'url' parameter")?;
+    
+    let mut request = HttpRequest::get(url);
+    
+    // Add headers if provided
+    if let Some(headers) = args["headers"].as_object() {
+        for (key, value) in headers {
+            if let Some(value_str) = value.as_str() {
+                request = request.header(key, value_str);
+            }
+        }
+    }
+    
+    let response = HttpClient::execute(request)
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+    
+    Ok(json!({
+        "status": response.status,
+        "headers": response.headers,
+        "body": response.text().unwrap_or_default()
+    }))
+}
+
+/// Make a generic HTTP POST request
+fn make_http_post(args: &Value) -> Result<Value, String> {
+    let url = args["url"].as_str()
+        .ok_or("Missing 'url' parameter")?;
+    
+    let mut request = HttpRequest::post(url);
+    
+    // Add headers if provided
+    if let Some(headers) = args["headers"].as_object() {
+        for (key, value) in headers {
+            if let Some(value_str) = value.as_str() {
+                request = request.header(key, value_str);
+            }
+        }
+    }
+    
+    // Add body if provided
+    if let Some(body) = args["body"].as_str() {
+        request = request.body(body.as_bytes());
+    } else if let Some(json_body) = args.get("json") {
+        request = request.json_value(json_body)
+            .map_err(|e| format!("Failed to serialize JSON body: {}", e))?;
+    }
+    
+    let response = HttpClient::execute(request)
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+    
+    Ok(json!({
+        "status": response.status,
+        "headers": response.headers,
+        "body": response.text().unwrap_or_default()
+    }))
+}
+
+/// Call a REST API with flexible parameters
+fn call_rest_api(args: &Value) -> Result<Value, String> {
+    let url = args["url"].as_str()
+        .ok_or("Missing 'url' parameter")?;
+    
+    let method = args["method"].as_str().unwrap_or("GET");
+    
+    let request = match method.to_uppercase().as_str() {
+        "GET" => HttpRequest::get(url),
+        "POST" => HttpRequest::post(url),
+        _ => return Err(format!("Unsupported HTTP method: {}", method)),
+    };
+    
+    // This would be extended to handle various REST API patterns
+    let response = HttpClient::execute(request)
+        .map_err(|e| format!("REST API call failed: {}", e))?;
+    
+    if response.is_success() {
+        // Try to parse as JSON if possible
+        match response.json_value() {
+            Ok(json_data) => Ok(json_data),
+            Err(_) => Ok(json!({
+                "text": response.text().unwrap_or_default()
+            }))
+        }
+    } else {
+        Err(format!("API call failed with status: {}", response.status))
+    }
+}
+
+// === Blockchain/Ethereum specific examples below ===
+// These demonstrate how the generic HTTP interface can be used for specific APIs
+
+/// Get block information by number or hash (Ethereum example)
+fn get_block_info(args: &Value) -> Result<Value, String> {
+    let node_url = args["node_url"].as_str()
+        .ok_or("Missing 'node_url' parameter")?;
+    
+    let block_number = args["block_number"].as_str().unwrap_or("latest");
+    
+    let request = JsonRpcRequest {
+        jsonrpc: "2.0".into(),
+        method: "eth_getBlockByNumber".into(),
+        params: json!([block_number, false]),
+        id: 1,
+    };
+
+    let response = make_rpc_call(node_url, &request)?;
+    
+    if let Some(error) = response.error {
+        return Err(format!("RPC Error: {} - {}", error.code, error.message));
+    }
+
+    Ok(response.result.unwrap_or_default())
+}
+
+/// Get account balance (Ethereum example)
+fn get_account_balance(args: &Value) -> Result<Value, String> {
+    let node_url = args["node_url"].as_str()
+        .ok_or("Missing 'node_url' parameter")?;
+    
+    let address = args["address"].as_str()
+        .ok_or("Missing 'address' parameter")?;
+    
+    let block_number = args["block_number"].as_str().unwrap_or("latest");
+
+    let request = JsonRpcRequest {
+        jsonrpc: "2.0".into(),
+        method: "eth_getBalance".into(),
+        params: json!([address, block_number]),
+        id: 1,
+    };
+
+    let response = make_rpc_call(node_url, &request)?;
+    
+    if let Some(error) = response.error {
+        return Err(format!("RPC Error: {} - {}", error.code, error.message));
+    }
+
+    Ok(json!({
+        "address": address,
+        "balance": response.result.unwrap_or_default(),
+        "block": block_number
+    }))
+}
+
+/// Get transaction information (Ethereum example)
+fn get_transaction(args: &Value) -> Result<Value, String> {
+    let node_url = args["node_url"].as_str()
+        .ok_or("Missing 'node_url' parameter")?;
+    
+    let tx_hash = args["tx_hash"].as_str()
+        .ok_or("Missing 'tx_hash' parameter")?;
+
+    let request = JsonRpcRequest {
+        jsonrpc: "2.0".into(),
+        method: "eth_getTransactionByHash".into(),
+        params: json!([tx_hash]),
+        id: 1,
+    };
+
+    let response = make_rpc_call(node_url, &request)?;
+    
+    if let Some(error) = response.error {
+        return Err(format!("RPC Error: {} - {}", error.code, error.message));
+    }
+
+    Ok(response.result.unwrap_or_default())
+}
+
+/// Make an eth_call to interact with smart contracts (Ethereum example)
+fn make_eth_call(args: &Value) -> Result<Value, String> {
+    let node_url = args["node_url"].as_str()
+        .ok_or("Missing 'node_url' parameter")?;
+    
+    let to = args["to"].as_str()
+        .ok_or("Missing 'to' parameter")?;
+    
+    let data = args["data"].as_str()
+        .ok_or("Missing 'data' parameter")?;
+    
+    let block_number = args["block_number"].as_str().unwrap_or("latest");
+
+    let call_object = json!({
+        "to": to,
+        "data": data
+    });
+
+    let request = JsonRpcRequest {
+        jsonrpc: "2.0".into(),
+        method: "eth_call".into(),
+        params: json!([call_object, block_number]),
+        id: 1,
+    };
+
+    let response = make_rpc_call(node_url, &request)?;
+    
+    if let Some(error) = response.error {
+        return Err(format!("RPC Error: {} - {}", error.code, error.message));
+    }
+
+    Ok(json!({
+        "to": to,
+        "data": data,
+        "result": response.result.unwrap_or_default(),
+        "block": block_number
+    }))
+}
+
+/// Test connection to blockchain node (Ethereum example)
+fn test_node_connection(args: &Value) -> Result<Value, String> {
+    let node_url = args["node_url"].as_str()
+        .ok_or("Missing 'node_url' parameter")?;
+
+    // Test with a simple eth_chainId call
+    let request = JsonRpcRequest {
+        jsonrpc: "2.0".into(),
+        method: "eth_chainId".into(),
+        params: json!([]),
+        id: 1,
+    };
+
+    let response = make_rpc_call(node_url, &request)?;
+    
+    if let Some(error) = response.error {
+        return Err(format!("RPC Error: {} - {}", error.code, error.message));
+    }
+
+    Ok(json!({
+        "node_url": node_url,
+        "chain_id": response.result.unwrap_or_default(),
+        "status": "connected"
+    }))
+}
+
+/// Show help information
+fn show_help() -> Result<Value, String> {
+    Ok(json!({
+        "description": "Portable HTTP Client for WASM - works in both browser and Valence environments",
+        "commands": {
+            "http_get": {
+                "description": "Make a generic HTTP GET request",
+                "parameters": {
+                    "url": "Target URL",
+                    "headers": "Optional headers object"
+                }
+            },
+            "http_post": {
+                "description": "Make a generic HTTP POST request",
+                "parameters": {
+                    "url": "Target URL",
+                    "headers": "Optional headers object",
+                    "body": "Request body (string)",
+                    "json": "Request body (JSON object)"
+                }
+            },
+            "rest_api": {
+                "description": "Call a REST API with flexible parameters",
+                "parameters": {
+                    "url": "API endpoint URL",
+                    "method": "HTTP method (GET, POST, etc.)"
+                }
+            },
+            "blockchain_examples": {
+                "get_block": {
+                    "description": "Get blockchain block information (Ethereum)",
+                    "parameters": {
+                        "node_url": "Blockchain node URL",
+                        "block_number": "Block number or 'latest' (optional)"
+                    }
+                },
+                "get_balance": {
+                    "description": "Get account balance (Ethereum)",
+                    "parameters": {
+                        "node_url": "Blockchain node URL",
+                        "address": "Ethereum address",
+                        "block_number": "Block number or 'latest' (optional)"
+                    }
+                },
+                "get_transaction": {
+                    "description": "Get transaction information (Ethereum)",
+                    "parameters": {
+                        "node_url": "Blockchain node URL",
+                        "tx_hash": "Transaction hash"
+                    }
+                },
+                "eth_call": {
+                    "description": "Call smart contract function (Ethereum)",
+                    "parameters": {
+                        "node_url": "Blockchain node URL",
+                        "to": "Contract address",
+                        "data": "Encoded function call data",
+                        "block_number": "Block number or 'latest' (optional)"
+                    }
+                },
+                "test_connection": {
+                    "description": "Test connection to blockchain node (Ethereum)",
+                    "parameters": {
+                        "node_url": "Blockchain node URL"
+                    }
+                }
+            }
+        }
+    }))
+}
+
+/// Make a JSON-RPC call using portable HTTP interface
+fn make_rpc_call(node_url: &str, request: &JsonRpcRequest) -> Result<JsonRpcResponse, String> {
+    // Convert to JSON Value for the portable interface
+    let request_value = serde_json::to_value(request)
+        .map_err(|e| format!("Failed to serialize request: {}", e))?;
+    
+    // Use the portable HTTP interface
+    let http_response = post_json_value(node_url, &request_value)
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+
+    if !http_response.is_success() {
+        return Err(format!("HTTP error: {}", http_response.status));
+    }
+
+    let response_value = http_response.json_value()
+        .map_err(|e| format!("Failed to parse JSON response: {}", e))?;
+    
+    let rpc_response: JsonRpcResponse = serde_json::from_value(response_value)
+        .map_err(|e| format!("Failed to deserialize response: {}", e))?;
+
+    Ok(rpc_response)
+} 

--- a/crates/runtime/wasm/src/lib.rs
+++ b/crates/runtime/wasm/src/lib.rs
@@ -8,5 +8,10 @@ pub use valence_coprocessor as core;
 #[cfg(feature = "std")]
 pub mod host;
 
+pub mod portable;
+
 /// Host controller identifier.
 pub const HOST_CONTROLLER: &str = "valence";
+
+// Re-export portable HTTP types
+pub use portable::{HttpClient, HttpRequest, HttpResponse, HttpError, HttpMethod, get, post, post_json_value};

--- a/crates/runtime/wasm/src/portable.rs
+++ b/crates/runtime/wasm/src/portable.rs
@@ -1,0 +1,238 @@
+//! Portable HTTP interface for cross-environment WASM compatibility
+//! 
+//! This module provides a common HTTP interface that can be compiled to work
+//! in both browser environments (using fetch) and Valence coprocessor environments
+//! (using the custom host function).
+
+extern crate alloc;
+
+use alloc::{string::String, vec::Vec, format};
+use core::fmt;
+use serde_json::Value;
+
+/// Portable HTTP request configuration
+#[derive(Debug, Clone)]
+pub struct HttpRequest {
+    pub url: String,
+    pub method: HttpMethod,
+    pub headers: Vec<(String, String)>,
+    pub body: Option<Vec<u8>>,
+    pub timeout_secs: Option<u64>,
+}
+
+/// HTTP methods
+#[derive(Debug, Clone)]
+pub enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Delete,
+    Patch,
+    Head,
+}
+
+impl fmt::Display for HttpMethod {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HttpMethod::Get => write!(f, "GET"),
+            HttpMethod::Post => write!(f, "POST"),
+            HttpMethod::Put => write!(f, "PUT"),
+            HttpMethod::Delete => write!(f, "DELETE"),
+            HttpMethod::Patch => write!(f, "PATCH"),
+            HttpMethod::Head => write!(f, "HEAD"),
+        }
+    }
+}
+
+/// Portable HTTP response
+#[derive(Debug, Clone)]
+pub struct HttpResponse {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Vec<u8>,
+}
+
+impl HttpRequest {
+    /// Create a new GET request
+    pub fn get(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            method: HttpMethod::Get,
+            headers: Vec::new(),
+            body: None,
+            timeout_secs: Some(30),
+        }
+    }
+
+    /// Create a new POST request
+    pub fn post(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            method: HttpMethod::Post,
+            headers: Vec::new(),
+            body: None,
+            timeout_secs: Some(30),
+        }
+    }
+
+    /// Add a header
+    pub fn header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.push((key.into(), value.into()));
+        self
+    }
+
+    /// Set the request body
+    pub fn body(mut self, body: impl Into<Vec<u8>>) -> Self {
+        self.body = Some(body.into());
+        self
+    }
+
+    /// Set JSON body (accepts any Value that can be serialized to JSON)
+    pub fn json_value(mut self, data: &Value) -> Result<Self, serde_json::Error> {
+        let json_str = serde_json::to_string(data)?;
+        self.body = Some(json_str.into_bytes());
+        self.headers.push((String::from("Content-Type"), String::from("application/json")));
+        Ok(self)
+    }
+
+    /// Set timeout in seconds
+    pub fn timeout(mut self, seconds: u64) -> Self {
+        self.timeout_secs = Some(seconds);
+        self
+    }
+}
+
+impl HttpResponse {
+    /// Check if the response was successful (2xx status)
+    pub fn is_success(&self) -> bool {
+        self.status >= 200 && self.status < 300
+    }
+
+    /// Get response body as string
+    pub fn text(&self) -> Result<String, core::str::Utf8Error> {
+        core::str::from_utf8(&self.body).map(|s| String::from(s))
+    }
+
+    /// Parse response body as JSON Value
+    pub fn json_value(&self) -> Result<Value, serde_json::Error> {
+        serde_json::from_slice(&self.body)
+    }
+
+    /// Get a header value
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.as_str())
+    }
+}
+
+/// Portable HTTP client that works in both browser and Valence environments
+pub struct HttpClient;
+
+impl HttpClient {
+    /// Execute an HTTP request
+    pub fn execute(request: HttpRequest) -> Result<HttpResponse, HttpError> {
+        // Always use Valence host for now
+        execute_valence_host(request)
+    }
+}
+
+/// HTTP error types
+#[derive(Debug)]
+pub enum HttpError {
+    /// Network error
+    Network(String),
+    /// Timeout error
+    Timeout,
+    /// Serialization error
+    Serialization(String),
+    /// Unsupported environment
+    UnsupportedEnvironment,
+    /// Invalid URL
+    InvalidUrl,
+    /// Invalid response
+    InvalidResponse,
+}
+
+impl fmt::Display for HttpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HttpError::Network(msg) => write!(f, "Network error: {}", msg),
+            HttpError::Timeout => write!(f, "Request timeout"),
+            HttpError::Serialization(msg) => write!(f, "Serialization error: {}", msg),
+            HttpError::UnsupportedEnvironment => write!(f, "Unsupported environment"),
+            HttpError::InvalidUrl => write!(f, "Invalid URL"),
+            HttpError::InvalidResponse => write!(f, "Invalid response"),
+        }
+    }
+}
+
+fn execute_valence_host(request: HttpRequest) -> Result<HttpResponse, HttpError> {
+    use crate::abi;
+    
+    // Convert headers to JSON object
+    let headers: serde_json::Map<String, Value> = request
+        .headers
+        .iter()
+        .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+        .collect();
+
+    // Build request JSON for Valence host function
+    let mut req_json = serde_json::json!({
+        "url": request.url,
+        "method": format!("{}", request.method).to_lowercase(),
+        "headers": headers,
+    });
+
+    // Add body if present
+    if let Some(body) = request.body {
+        req_json["body"] = Value::Array(body.iter().map(|&b| Value::Number(b.into())).collect());
+    }
+
+    // Make the HTTP request through Valence host function
+    let response = abi::http(&req_json)
+        .map_err(|e| HttpError::Network(format!("{}", e)))?;
+
+    // Parse response
+    let status = response["status"].as_u64().ok_or(HttpError::InvalidResponse)? as u16;
+    
+    let headers: Vec<(String, String)> = response["headers"]
+        .as_object()
+        .unwrap_or(&serde_json::Map::new())
+        .iter()
+        .map(|(k, v)| (k.clone(), String::from(v.as_str().unwrap_or(""))))
+        .collect();
+
+    let body = match &response["body"] {
+        Value::Array(arr) => arr
+            .iter()
+            .map(|v| v.as_u64().unwrap_or(0) as u8)
+            .collect(),
+        Value::String(s) => s.as_bytes().to_vec(),
+        _ => Vec::new(),
+    };
+
+    Ok(HttpResponse {
+        status,
+        headers,
+        body,
+    })
+}
+
+/// Convenience function for making GET requests
+pub fn get(url: impl Into<String>) -> Result<HttpResponse, HttpError> {
+    HttpClient::execute(HttpRequest::get(url))
+}
+
+/// Convenience function for making POST requests
+pub fn post(url: impl Into<String>) -> Result<HttpResponse, HttpError> {
+    HttpClient::execute(HttpRequest::post(url))
+}
+
+/// Convenience function for making JSON POST requests with serde_json::Value
+pub fn post_json_value(url: impl Into<String>, data: &Value) -> Result<HttpResponse, HttpError> {
+    let request = HttpRequest::post(url).json_value(data)
+        .map_err(|e| HttpError::Serialization(format!("{}", e)))?;
+    HttpClient::execute(request)
+} 

--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,7 @@
           # Use provided RUST_LOG or default
           export RUST_LOG="''${RUST_LOG:-$RUST_LOG_DEFAULT}"
           
-          echo "🚀 Starting Valence co-processor service..."
+          echo "Starting Valence co-processor service..."
           echo "RUST_LOG: $RUST_LOG"
           echo "VALENCE_PROVER_SECRET: ''${VALENCE_PROVER_SECRET:-"[not set - using public service]"}"
           echo "Prover host: $PROVER_HOST"
@@ -102,7 +102,7 @@
           
           # Check if VALENCE_PROVER_SECRET is set
           if [ -z "''${VALENCE_PROVER_SECRET:-}" ]; then
-            echo "⚠️  Warning: VALENCE_PROVER_SECRET not set. Using public prover service."
+            echo "Warning: VALENCE_PROVER_SECRET not set. Using public prover service."
             echo "   To use dedicated prover, set: export VALENCE_PROVER_SECRET=your_secret"
             echo ""
           fi
@@ -122,7 +122,7 @@
           PROVER_HOST="''${VALENCE_PROVER_HOST:-${proverHostDefault}}"
           export RUST_LOG="''${RUST_LOG:-info,valence_coprocessor=debug,valence_coprocessor_wasm=debug}"
           
-          echo "🚀 Starting Valence co-processor service (release mode)..."
+          echo "Starting Valence co-processor service (release mode)..."
           echo "RUST_LOG: $RUST_LOG"
           echo "VALENCE_PROVER_SECRET: ''${VALENCE_PROVER_SECRET:-"[not set]"}"
           echo ""
@@ -256,25 +256,25 @@
           bash.extra = ''
             source ${env-setup-script}
             
-            echo "🚀 Valence co-processor development environment"
+            echo "Valence co-processor development environment"
             echo ""
-            echo "📋 Available commands (use 'menu' to see all):"
+            echo "Available commands (use 'menu' to see all):"
             echo "  start-service              - Start the service (VALENCE_PROVER_SECRET=secret start-service)"
             echo "  start-service-release      - Start service in release mode"
             echo "  lint-code                  - Run clippy linting"
             echo "  install-cli                - Install cargo-valence CLI tool globally"
             echo "  test-service               - Check if service is responding"
             echo ""
-            echo "📖 README examples:"
+            echo "README examples:"
             echo "  VALENCE_PROVER_SECRET=secret start-service"
             echo "  RUST_LOG=info,valence_coprocessor=debug,valence_coprocessor_wasm=debug start-service"
             echo ""
-            echo "🗄️  Redis (for local development):"
+            echo "Redis (for local development):"
             echo "  redis-start                - Start Redis server"
             echo "  redis-client               - Redis CLI client"
             echo ""
-            echo "🌍 Public service: http://prover.timewave.computer:37281/"
-            echo "📱 CLI installation: cargo install --git https://github.com/timewave-computer/valence-coprocessor.git --locked cargo-valence"
+            echo "Public service: http://prover.timewave.computer:37281/"
+            echo "CLI installation: cargo install --git https://github.com/timewave-computer/valence-coprocessor.git --locked cargo-valence"
           '';
         };
       };


### PR DESCRIPTION
I was doing a little work on valence-domain-clients yesterday getting wasm builds working so we can use them for browser client applications. While doing that, I realized it would be nice if we could use those same builds for coprocessor applications. This PR adds an API to the wasm runtime that mirrors the browser http interface, enabling us to experiment with cross-compatible client builds.